### PR TITLE
Introduce documentation for reaching the dogebox using mDNS domain name

### DIFF
--- a/src/installation/setup.md
+++ b/src/installation/setup.md
@@ -1,5 +1,9 @@
 # Dogebox Initial Setup
 
+On the first boot of your dogebox, the system will be available on https://dogebox.local:8080/.
+
+In case your network blocks mDNS, which can happen in some cases use the following methods to determine the IP address of the machine.
+
 ## Determine your IP address
 
 <div class="warning">
@@ -24,7 +28,7 @@ Unfortunately this is out-of-scope for this documentation, but a quick google of
 
 ## Visit setup UI
 
-Once you've got your IP address, continue setup by visiting the Web UI. This is hosted on port `8080` on the IP address.
+Once you've got your IP address or confirmed the box is available on dogebox.local, continue setup by visiting the Web UI. This is hosted on port `8080`.
 
 eg. If your IP address is `192.168.0.2`, you should visit `http://192.168.0.2:8080` in your browser.
 

--- a/src/installation/setup/configuration.md
+++ b/src/installation/setup/configuration.md
@@ -14,7 +14,7 @@ Here we have some basic system configuration options.
 
 #### Device Name
 
-This is what your devices `hostname` will be set to. This may be used for additional features in the future.
+This is what your devices `hostname` will be set to. The value chosen here will determine the mDNS address you will be able to access the WebUI with later on. E.g. if you choose `my-dogebox` then you'll be able to access the WebUI at https://my-dogebox.local:8080/.
 
 #### Keyboard Layout
 

--- a/src/installation/t6.md
+++ b/src/installation/t6.md
@@ -36,6 +36,8 @@ You can easly flash using the OpenSource Rufus Tool that you can get the latest 
 
 ## How to Setup
 
+With a monitor and keyboard available
+
 - Insert the MicroSD card with image flashed.
 - Ensure you have an ethernet cable plugged into your T6 box.
 - Plug in a HDMI screen, make sure it's plugged into `HDMI1`.
@@ -50,6 +52,16 @@ You can easly flash using the OpenSource Rufus Tool that you can get the latest 
 - In a web browser, visit `http://your_ip_address:8080` to start configuring your dogebox.
   - In this example, it would be `http://192.168.1.5:8080` but your IP address will be different.
   - This will load the DogeBox Setup page.
+
+Without a monitor and keyboard available
+
+- Insert the MicroSD card with image flashed.
+- Ensure you have an ethernet cable plugged into your T6 box.
+- Plug power in.
+- Wait until the box finishes booting, this could take anywhere from 2 to 10 minutes.
+- In a web browser, visit `https://dogebox.local:8080` to start configuring your dogebox.
+  - This will load the DogeBox Setup page.
+
 
 <p><img src="../images/vb5.PNG" alt="How to find your IP address" width="70%" style="margin-left:1em;"/></p>
 


### PR DESCRIPTION
This describes the steps to take with mDNS enabled network (some networks may not allow mDNS discovery, so IP-address method will still be relevant)

I also put in to use `https`, which currently isn't implemented, so that will need to wait for proper implementation before the docs are fully ready.

Having https will hopefully allow us to use the cloud reflector service